### PR TITLE
Update example to use RDS Postgres v15.3

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -41,10 +41,10 @@ Example that uses the module with many of its configurations. Used in CI E2E tes
 | <a name="input_rds_db_name"></a> [rds\_db\_name](#input\_rds\_db\_name) | The name of the database to create when the DB instance is created. | `string` | `"example"` | no |
 | <a name="input_rds_deletion_protection"></a> [rds\_deletion\_protection](#input\_rds\_deletion\_protection) | If the DB instance should have deletion protection enabled. | `bool` | `false` | no |
 | <a name="input_rds_engine"></a> [rds\_engine](#input\_rds\_engine) | The database engine to use. | `string` | `"postgres"` | no |
-| <a name="input_rds_engine_version"></a> [rds\_engine\_version](#input\_rds\_engine\_version) | The database engine version. | `string` | `"14.1"` | no |
-| <a name="input_rds_family"></a> [rds\_family](#input\_rds\_family) | The family of the DB parameter group. | `string` | `"postgres14"` | no |
+| <a name="input_rds_engine_version"></a> [rds\_engine\_version](#input\_rds\_engine\_version) | The database engine version. | `string` | `"15.3"` | no |
+| <a name="input_rds_family"></a> [rds\_family](#input\_rds\_family) | The family of the DB parameter group. | `string` | `"postgres15"` | no |
 | <a name="input_rds_instance_class"></a> [rds\_instance\_class](#input\_rds\_instance\_class) | The instance type of the RDS instance. | `string` | `"db.t4g.large"` | no |
-| <a name="input_rds_major_engine_version"></a> [rds\_major\_engine\_version](#input\_rds\_major\_engine\_version) | The major version of the engine that this option group should be associated with. | `string` | `"14"` | no |
+| <a name="input_rds_major_engine_version"></a> [rds\_major\_engine\_version](#input\_rds\_major\_engine\_version) | The major version of the engine that this option group should be associated with. | `string` | `"15"` | no |
 | <a name="input_rds_max_allocated_storage"></a> [rds\_max\_allocated\_storage](#input\_rds\_max\_allocated\_storage) | The upper limit (in gigabytes) to which Amazon RDS can automatically scale the storage of the DB instance. | `number` | `40` | no |
 | <a name="input_rds_password"></a> [rds\_password](#input\_rds\_password) | Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file.<br>  The password provided will not be used if the variable create\_random\_password is set to true. | `string` | `null` | no |
 | <a name="input_rds_username"></a> [rds\_username](#input\_rds\_username) | Username for the master DB user. | `string` | `"exampleadmin"` | no |

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -38,19 +38,19 @@ variable "rds_engine" {
 variable "rds_engine_version" {
   description = "The database engine version."
   type        = string
-  default     = "14.1"
+  default     = "15.3"
 }
 
 variable "rds_family" {
   description = "The family of the DB parameter group."
   type        = string
-  default     = "postgres14"
+  default     = "postgres15"
 }
 
 variable "rds_major_engine_version" {
   description = "The major version of the engine that this option group should be associated with."
   type        = string
-  default     = "14"
+  default     = "15"
 }
 
 variable "rds_instance_class" {


### PR DESCRIPTION
Looks like 14.1 has been deprecated and isn't able to be deployed anymore. 15.3 is the latest stable version (i.e. not beta/release-candidate)