### PR TITLE
Restrict testing to US regions and remove dependency on UDS VPC module.

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -71,6 +71,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
@@ -78,13 +79,14 @@ No outputs.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_rds"></a> [rds](#module\_rds) | ../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/defenseunicorns/terraform-aws-uds-vpc.git | v0.0.2-alpha |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.1.1 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [random_id.default](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "random_id" "default" {
   byte_length = 2
 }
@@ -9,12 +13,13 @@ locals {
 }
 
 module "vpc" {
-  source = "git::https://github.com/defenseunicorns/terraform-aws-uds-vpc.git?ref=v0.0.2-alpha"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.1"
 
   name                  = local.vpc_name
-  vpc_cidr              = "10.200.0.0/16"
+  cidr                  = "10.200.0.0/16"
   secondary_cidr_blocks = ["100.64.0.0/16"] # Used for optimizing IP address usage by pods in an EKS cluster. See https://aws.amazon.com/blogs/containers/optimize-ip-addresses-usage-by-pods-in-your-amazon-eks-cluster/
-  azs                   = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  azs                   = [for az_name in slice(data.aws_availability_zones.available.names, 0, min(length(data.aws_availability_zones.available.names), 3)) : az_name]
   public_subnets        = [for k, v in module.vpc.azs : cidrsubnet(module.vpc.vpc_cidr_block, 5, k)]
   private_subnets       = [for k, v in module.vpc.azs : cidrsubnet(module.vpc.vpc_cidr_block, 5, k + 4)]
   database_subnets      = [for k, v in module.vpc.azs : cidrsubnet(module.vpc.vpc_cidr_block, 5, k + 8)]

--- a/test/examples_complete_test.go
+++ b/test/examples_complete_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	teststructure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"testing"
@@ -8,6 +9,10 @@ import (
 )
 
 func TestExamplesComplete(t *testing.T) {
+	var approvedRegions = []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2"}
+	awsRegion := "us-west-1" //aws.GetRandomStableRegion(t, approvedRegions, nil)
+	backupAwsRegion := aws.GetRandomStableRegion(t, approvedRegions, []string{awsRegion})
+
 	t.Parallel()
 	tempFolder := teststructure.CopyTerraformFolderToTemp(t, "..", "examples/complete")
 	terraformOptions := &terraform.Options{
@@ -20,8 +25,8 @@ func TestExamplesComplete(t *testing.T) {
 		TimeBetweenRetries: 5 * time.Second,
 		Vars: map[string]interface{}{
 			"name_prefix":                "ci",
-			"region":                     "us-east-1",
-			"region2":                    "us-east-2",
+			"region":                     awsRegion,
+			"region2":                    backupAwsRegion,
 			"rds_create_random_password": false,
 			"rds_password":               "my-password",
 			"tags": map[string]string{

--- a/test/examples_complete_test.go
+++ b/test/examples_complete_test.go
@@ -25,8 +25,8 @@ func TestExamplesComplete(t *testing.T) {
 		TimeBetweenRetries: 5 * time.Second,
 		Vars: map[string]interface{}{
 			"name_prefix":                     "ci",
-			"region":                          "us-east-1",
-			"region2":                         "us-east-2",
+			"region":                          awsRegion,
+			"region2":                         backupAwsRegion,
 			"rds_manage_master_user_password": false,
 			"rds_password":                    "my-password",
 			"tags": map[string]string{

--- a/test/examples_complete_test.go
+++ b/test/examples_complete_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestExamplesComplete(t *testing.T) {
 	var approvedRegions = []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2"}
-	awsRegion := "us-west-1" //aws.GetRandomStableRegion(t, approvedRegions, nil)
+	awsRegion := aws.GetRandomStableRegion(t, approvedRegions, nil)
 	backupAwsRegion := aws.GetRandomStableRegion(t, approvedRegions, []string{awsRegion})
 
 	t.Parallel()

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -2,8 +2,8 @@ package e2e_test
 
 import (
 	"context"
-	"os"
 	utils "e2e_test/test/utils"
+	"os"
 	"testing"
 	"time"
 )


### PR DESCRIPTION
Tested with `go test -timeout 40m` in the `test` dir.  I specifically tested with us-west-1, because it only has 2 AZs.