### PR TITLE
Allow Renovate to automerge for minor and patch updates.

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -69,6 +69,11 @@
       matchDepTypes: ["module"],
       matchDatasources: ["github-tags", "git-tags"],
       versioning: "loose"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/", // exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time according to the SemVer spec
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
This will allow Renovate to automerge updates for minor and patch updates [unless they are version 0.x](https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates).  Renovate will still cut a PR and will only automerge if all checks are green.  This behavior will essentially be equal to what I do with these PRs:  (any breaking changes == false) && (all checks pass == true) -> approve and merge.

It is still unclear to me if these PRs will be auto approved to allow Renovate to automerge.

[Renovate docs](https://docs.renovatebot.com/configuration-options/#automerge)